### PR TITLE
feat(CompoundType): Improve error log on CompoundType.addField and CompoundType.setBodyParsed when body is already parsed

### DIFF
--- a/src/java/com/jogamp/gluegen/cgram/types/CompoundType.java
+++ b/src/java/com/jogamp/gluegen/cgram/types/CompoundType.java
@@ -192,7 +192,9 @@ public abstract class CompoundType extends MemoryLayoutType implements Cloneable
   /** Adds a field to this type. */
   public void addField(final Field f) {
     if (bodyParsed) {
-      throw new IllegalStateException("Body of this CompoundType has been already closed");
+      throw new IllegalStateException(String.format(
+              "Body of this CompoundType (%s) has been already closed (Field supplied %s)", this, f
+      ));
     }
     if (fields == null) {
       fields = new ArrayList<Field>();
@@ -208,7 +210,9 @@ public abstract class CompoundType extends MemoryLayoutType implements Cloneable
    */
   public void setBodyParsed() throws IllegalStateException {
     if (bodyParsed) {
-        throw new IllegalStateException("Body of this CompoundType has been already closed");
+      throw new IllegalStateException(String.format(
+              "Body of this CompoundType (%s) has been already closed", this
+      ));
     }
     bodyParsed = true;
   }


### PR DESCRIPTION
Here is a small modification to make it easier to debug CompoundType in case of failure during field addition.