### PR TITLE
feat(generation): Add setter generation for not constant and not opaque compound attribute

### DIFF
--- a/src/java/com/jogamp/gluegen/JavaEmitter.java
+++ b/src/java/com/jogamp/gluegen/JavaEmitter.java
@@ -1140,6 +1140,20 @@ public class JavaEmitter implements GlueEmitter {
                                        field + "\" in type \"" + structCTypeName + "\")",
                                        fieldType.getASTLocusTag());
           }
+          if( !immutableField && !fieldType.isConst() ) {
+              // Setter
+              generateSetterSignature(javaUnit, MethodAccess.PUBLIC, false, false, fieldName, fieldType, Ownership.Parent, containingJTypeName, CodeGenUtils.capitalizeString(fieldName), null, fieldType.getName(), null, false, false, null, null, null);
+              javaUnit.emitln(" {");
+              javaUnit.emitln("    final ByteBuffer bb = src.getBuffer();");
+              javaUnit.emitln("    final int size = "+fieldName+"_size[mdIdx];");
+              javaUnit.emitln("    final byte[] content = new byte[size];");
+              javaUnit.emitln("    bb.get(content, 0, size);");
+              javaUnit.emitln("    accessor.setBytesAt("+fieldName+"_offset[mdIdx], content);");
+              javaUnit.emitln("    return this;");
+              javaUnit.emitln("  }");
+              javaUnit.emitln();
+          }
+          // Getter
           generateGetterSignature(javaUnit, false, false, fieldName, fieldType, Ownership.Parent, fieldType.getName(), CodeGenUtils.capitalizeString(fieldName), null, false, false, null, null);
           javaUnit.emitln(" {");
           javaUnit.emitln("    return " + fieldType.getName() + ".create( accessor.slice( " +

--- a/src/junit/com/jogamp/gluegen/test/junit/generation/BaseClass.java
+++ b/src/junit/com/jogamp/gluegen/test/junit/generation/BaseClass.java
@@ -2052,6 +2052,12 @@ public class BaseClass extends SingletonJunitCase {
 
     /** Primitive.VariaValue.Struct.Pointer - write access */
     private void chapter12_06bTestTKFieldVariaValueStructWriteAccess(final TK_Field model) {
+        {
+            final TK_Dimension val = createTKDim(0, 1, 50, 61);
+            model.setVariaStructElement(val);
+            Assert.assertTrue( equals(val, model.getVariaStructElement()) );
+        }
+
         Assert.assertEquals(1, TK_Field.getVariaStructPointerConstOneElemElemCount());
         Assert.assertEquals(false, model.isVariaStructPointerConstOneElemNull());
         {

--- a/src/junit/com/jogamp/gluegen/test/junit/generation/test1.c
+++ b/src/junit/com/jogamp/gluegen/test/junit/generation/test1.c
@@ -690,7 +690,8 @@ typedef struct {
     TK_Dimension* constStructPointerCustomLen;
     int32_t       constStructPointerCustomLenElemCount;
 
-    // Struct.VariaValue 2A + 5P = 7
+    // Struct.VariaValue 1S + 2A + 5P = 8
+    TK_Dimension  variaStructElement;
     TK_Dimension  variaStructArrayConstOneElem[1];
     TK_Dimension  variaStructArrayConstLen[3];
     TK_Dimension* variaStructPointerConstOneElem;
@@ -870,7 +871,11 @@ static TK_FieldMutable * createTKFieldMutable() {
     s->constStructPointerCustomLen[3].height = 164;
     s->constStructPointerCustomLenElemCount = 4;
 
-    // Struct.VariaValue.TK_Dimension 2A + 5P = 7
+    // Struct.VariaValue.TK_Dimension 1S + 2A + 5P = 8
+    s->variaStructElement.x = 47;
+    s->variaStructElement.y = 48;
+    s->variaStructElement.width = 49;
+    s->variaStructElement.height = 50;
     s->variaStructArrayConstOneElem[0].x = 51;
     s->variaStructArrayConstOneElem[0].y = 52;
     s->variaStructArrayConstOneElem[0].width = 53;

--- a/src/junit/com/jogamp/gluegen/test/junit/generation/test1.h
+++ b/src/junit/com/jogamp/gluegen/test/junit/generation/test1.h
@@ -505,7 +505,8 @@ typedef struct {
     const TK_Dimension* constStructPointerCustomLen;
     int32_t             constStructPointerCustomLenElemCount;
 
-    // Struct.VariaValue 2A + 5P = 7
+    // Struct.VariaValue 1S + 2A + 5P = 8
+    TK_Dimension  variaStructElement;
     TK_Dimension  variaStructArrayConstOneElem[1];
     TK_Dimension  variaStructArrayConstLen[3];
     TK_Dimension* variaStructPointerConstOneElem;
@@ -606,7 +607,8 @@ typedef struct {
     const TK_Dimension* constStructPointerCustomLen;
     int32_t             constStructPointerCustomLenElemCount;
 
-    // Struct.VariaValue 2A + 5P = 7
+    // Struct.VariaValue 1S + 2A + 5P = 8
+    TK_Dimension  variaStructElement;
     TK_Dimension  variaStructArrayConstOneElem[1];
     TK_Dimension  variaStructArrayConstLen[3];
     TK_Dimension* variaStructPointerConstOneElem;
@@ -707,7 +709,8 @@ typedef struct {
     const TK_Dimension* constStructPointerCustomLen;
     int32_t             constStructPointerCustomLenElemCount;
 
-    // Struct.VariaValue 2A + 5P = 7
+    // Struct.VariaValue 1S + 2A + 5P = 8
+    TK_Dimension  variaStructElement;
     TK_Dimension  variaStructArrayConstOneElem[1];
     TK_Dimension  variaStructArrayConstLen[3];
     TK_Dimension* variaStructPointerConstOneElem;


### PR DESCRIPTION
Here is ~~fine addition to my collection~~ addition of setter in the case with non-constant compound field, not in an array and not by address, in order to allow its contents to be modified.