### PR TITLE
feat(callbackGenerator): Add basic management of callback without userData

### DIFF
--- a/doc/GlueGen_Mapping.md
+++ b/doc/GlueGen_Mapping.md
@@ -826,9 +826,9 @@ as it is core to the semantic mapping of all resources. They also have to use th
 
 `JavaCallbackDef` attributes:
 - `SetCallbackFunction`: `SetCallbackFunction` name of the native toolkit API responsible to set the callback
-- `SetCallback-UserParamIndex`: `UserParam` parameter-index of the `SetCallbackFunction`
+- `SetCallback-UserParamIndex`: `UserParam` parameter-index of the `SetCallbackFunction` or negative index to disable UserParam management
 - `CallbackFunctionType`: The native toolkit API typedef-name of the function-pointer-type, aka the callback type name
-- `CallbackFunction-UserParamIndex`: The `userParam` parameter-index of the `CallbackFunctionType`, which allows to [indicate a heterogeneous `UserParam`](#struct-type-user-param-heterogeneous)
+- `CallbackFunction-UserParamIndex`: The `userParam` parameter-index of the `CallbackFunctionType`, which allows to [indicate a heterogeneous `UserParam`](#struct-type-user-param-heterogeneous) or negative index to disable UserParam management
 - `Callback-UserParamClass`: Optional [custom *UserParamClass*](#custom-callback-userparamclass) overriding the default `Object` for non-compound `UserParam` types.
 - `Callback-KeyClass`: Optional [custom *KeyClass*](#custom-callback-keyclass), providing the hash-map-key.
 
@@ -1328,6 +1328,72 @@ leading to the following interface
 
   /** Entry point (through function pointer) to C language function: <br> <code>void MessageCallback11bInject(size_t id, long val)</code><br>   */
   public void MessageCallback11bInject(long id, long val);
+```
+
+### JavaCallback Example 12 (Without UserParam)
+
+This example demonstrates a JavaCallBack without user param and only a global key. 
+
+The callback `T2_CallbackFunc12` is managed by the toolkit and passed to the callback function, while user passes JavaCallback to the registration method `SetLogCallBack(..)`.
+
+
+C-API Header snipped
+```
+  typedef enum {
+    LOG_Off = 0,
+    LOG_Fatal = 100,
+    LOG_Error = 200,
+    LOG_Warning = 300,
+    LOG_Info = 400,
+    LOG_Verbose = 500,
+    LOG_VeryVerbose = 600
+  } LogLevel;
+
+  typedef struct {
+    const char* Category;
+    const char* Message;
+    LogLevel Level;
+  } LogMessage;
+
+  typedef void ( * T2_CallbackFunc12)(const LogMessage* usrParam);
+
+  void SetLogCallBack(T2_CallbackFunc12 cbFunc);
+  void LogCallBackInject(const LogMessage* message);
+```
+
+and the following GlueGen configuration
+```
+  ReturnsStringOnly LogMessage.Category
+  ReturnsStringOnly LogMessage.Message
+
+  JavaCallbackDef SetLogCallBack -1 T2_CallbackFunc12 -1
+```
+
+leading to the following interface
+```
+
+  /** JavaCallback interface: T2_CallbackFunc12 -> void (*T2_CallbackFunc12)(const LogMessage *  usrParam) */
+  public static interface T2_CallbackFunc12 {
+    /** Interface to C language function: <br> <code>void callback(const LogMessage *  usrParam)</code><br>Alias for: <code>T2_CallbackFunc12</code>     */
+    public void callback(LogMessage usrParam);
+  }
+  
+  ...
+
+  /** Returns if callback is mapped for <br> <code>  void SetLogCallBack(T2_CallbackFunc12 cbFunc)</code> */
+  public boolean isSetLogCallBackMapped();
+
+  /** Returns T2_CallbackFunc12 callback for <br> <code>  void SetLogCallBack(T2_CallbackFunc12 cbFunc)</code> */
+  public T2_CallbackFunc12 getSetLogCallBack();
+
+  /** Releases callback data skipping toolkit API. Favor passing `null` callback ref to <br> <code>  void SetLogCallBack(T2_CallbackFunc12 cbFunc)</code> */
+  public void releaseSetLogCallBack();
+
+  /** Entry point (through function pointer) to C language function: <br> <code>void SetLogCallBack(T2_CallbackFunc12 cbFunc)</code><br>   */
+  public void SetLogCallBack(T2_CallbackFunc12 cbFunc);
+
+  /** Entry point (through function pointer) to C language function: <br> <code>void LogCallBackInject(const LogMessage *  message)</code><br>   */
+  public void LogCallBackInject(LogMessage message);
 ```
 
 *TODO: Enhance documentation*

--- a/src/java/com/jogamp/gluegen/CMethodBindingEmitter.java
+++ b/src/java/com/jogamp/gluegen/CMethodBindingEmitter.java
@@ -427,7 +427,7 @@ public class CMethodBindingEmitter extends FunctionEmitter {
     emitBodyUserVariableDeclarations();
     emitBodyVariablePreCallSetup();
     if( null != javaCallbackEmitter ) {
-        javaCallbackEmitter.emitCSetFuncPreCall(unit);
+        javaCallbackEmitter.emitCSetFuncPreCall(unit, jcbCMethodEmitter);
     }
     emitBodyCallCFunction();
     emitBodyUserVariableAssignments();

--- a/src/java/com/jogamp/gluegen/JavaConfiguration.java
+++ b/src/java/com/jogamp/gluegen/JavaConfiguration.java
@@ -2423,6 +2423,8 @@ public class JavaConfiguration {
       final String cbFuncUserParamName;
       final Type cbFuncUserParamType;
 
+      final boolean cbUserParamIsDefined;
+
       final String setFuncName;
       final List<Integer> setFuncKeyIndices;
       final int setFuncUserParamIdx;
@@ -2442,7 +2444,8 @@ public class JavaConfiguration {
           this.staticCBMethodSignature = staticCBMethodSignature;
           this.cbFuncType = cbFuncType;
           this.cbFuncBinding = cbFuncBinding;
-          {
+          this.cbUserParamIsDefined = setFuncUserParamIdx >= 0;
+          if( cbUserParamIsDefined ) {
               int paramIdx = -2;
               Type paramType = null;
               String paramName = null;
@@ -2456,10 +2459,14 @@ public class JavaConfiguration {
                   }
               }
               this.cbFuncUserParamIdx = paramIdx;
-              this.cbFuncKeyIndices = cbFuncKeyIndices;
               this.cbFuncUserParamName = paramName;
               this.cbFuncUserParamType = paramType;
+          } else {
+              this.cbFuncUserParamIdx = -1;
+              this.cbFuncUserParamName = null;
+              this.cbFuncUserParamType = null;
           }
+          this.cbFuncKeyIndices = cbFuncKeyIndices;
           this.setFuncName = setFuncName;
           this.setFuncKeyIndices = setFuncKeyIndices;
           this.setFuncUserParamIdx = setFuncUserParamIdx;
@@ -2499,9 +2506,9 @@ public class JavaConfiguration {
 
       @Override
       public String toString() {
-          return String.format("JavaCallbackInfo[cbFunc[%s%s, userParam[idx %d, '%s', %s, keys %s], set[%s(ok %b, cbIdx %d, upIdx %d, keys %s], Class[UserParam '%s', Key '%s'], %s]",
+          return String.format("JavaCallbackInfo[cbFunc[%s%s, userParam[defined %b, idx %d, '%s', %s, keys %s], set[%s(ok %b, cbIdx %d, upIdx %d, keys %s], Class[UserParam '%s', Key '%s'], %s]",
                   cbFuncTypeName, staticCBMethodSignature,
-                  cbFuncUserParamIdx, cbFuncUserParamName, cbFuncUserParamType.getSignature(null).toString(), cbFuncKeyIndices.toString(),
+                  cbUserParamIsDefined, cbFuncUserParamIdx, cbFuncUserParamName, cbUserParamIsDefined ? cbFuncUserParamType.getSignature(null).toString() : null, cbFuncKeyIndices.toString(),
                   setFuncName, setFuncProcessed, setFuncCBParamIdx, setFuncUserParamIdx,
                   setFuncKeyIndices.toString(), userParamClassName, customKeyClassName,
                   cbFuncType.toString(cbFuncTypeName, false, true));

--- a/src/java/com/jogamp/gluegen/JavaEmitter.java
+++ b/src/java/com/jogamp/gluegen/JavaEmitter.java
@@ -465,9 +465,12 @@ public class JavaEmitter implements GlueEmitter {
       final boolean isUnimplemented = cfg.isUnimplemented(cSymbol);
       final List<String> prologue = cfg.javaPrologueForMethod(binding, false, false);
       final List<String> epilogue = cfg.javaEpilogueForMethod(binding, false, false);
+      final JavaCallbackInfo jcbi = cfg.setFuncToJavaCallbackMap.get(binding.getName());
+      final boolean needsIntermediateOperation = null != jcbi && !jcbi.cbUserParamIsDefined;
       final boolean needsBody = isUnimplemented ||
                                 binding.needsNIOWrappingOrUnwrapping() ||
                                 binding.signatureUsesJavaPrimitiveArrays() ||
+                                needsIntermediateOperation ||
                                 null != prologue  ||
                                 null != epilogue;
 
@@ -531,6 +534,8 @@ public class JavaEmitter implements GlueEmitter {
       final boolean hasPrologueOrEpilogue =
               cfg.javaPrologueForMethod(binding, false, false) != null ||
               cfg.javaEpilogueForMethod(binding, false, false) != null ;
+      final JavaCallbackInfo jcbi = cfg.setFuncToJavaCallbackMap.get(binding.getName());
+      final boolean needsIntermediateOperation = null != jcbi && !jcbi.cbUserParamIsDefined;
 
       if ( !cfg.isUnimplemented( cSymbol ) ) {
           // If we already generated a public native entry point for this
@@ -541,7 +546,7 @@ public class JavaEmitter implements GlueEmitter {
           //   the private native entry point for it along with the version
           //   taking only NIO buffers
           if ( !binding.signatureUsesJavaPrimitiveArrays() &&
-               ( binding.needsNIOWrappingOrUnwrapping() || hasPrologueOrEpilogue )
+               ( binding.needsNIOWrappingOrUnwrapping() || hasPrologueOrEpilogue || needsIntermediateOperation )
              )
           {
               final CodeUnit unit = (cfg.allStatic() ? javaUnit() : javaImplUnit());
@@ -588,7 +593,7 @@ public class JavaEmitter implements GlueEmitter {
                               cfg.implClassName(),
                               true, // NOTE: we always disambiguate with a suffix now, so this is optional
                               cfg.allStatic(),
-                              (binding.needsNIOWrappingOrUnwrapping() || hasPrologueOrEpilogue),
+                              (binding.needsNIOWrappingOrUnwrapping() || hasPrologueOrEpilogue || needsIntermediateOperation),
                               !cfg.useNIODirectOnly(binding.getName()),
                               machDescJava, getConfig());
               prepCEmitter(binding.getName(), binding.getJavaReturnType(), cEmitter);
@@ -1528,11 +1533,11 @@ public class JavaEmitter implements GlueEmitter {
           methodSignature.append("(");
           for(int i=0; i<mb.getNumArguments(); ++i) {
               final JavaType t = mb.getJavaArgumentType(i);
-              methodSignature.append(t.getDescriptor());
+              methodSignature.append(t.getDescriptor(cfg));
           }
           methodSignature.append(")");
           final JavaType rt = mb.getJavaReturnType();
-          methodSignature.append(rt.getDescriptor());
+          methodSignature.append(rt.getDescriptor(cfg));
       }
 
       // JavaTypes representing C pointers in the initial

--- a/src/java/com/jogamp/gluegen/JavaType.java
+++ b/src/java/com/jogamp/gluegen/JavaType.java
@@ -282,6 +282,10 @@ public class JavaType {
    * Returns the Java type name corresponding to this type.
    */
   public String getName() {
+    return getName(null);
+  }
+
+  public String getName(final JavaConfiguration cfg) {
     if (clazz != null) {
       if (clazz.isArray()) {
         return arrayName(clazz);
@@ -289,29 +293,29 @@ public class JavaType {
       return clazz.getName();
     }
     if( clazzName != null ) {
-        return clazzName;
+        return (null != cfg ? (cfg.packageForStruct(clazzName) + ".") : "") + clazzName;
     }
     if (elementType != null) {
       return elementType.getName();
     }
-    return structName;
+    return (null != cfg ? (cfg.packageForStruct(clazzName) + ".") : "") + structName;
   }
 
   /**
    * Returns the descriptor (internal type signature) corresponding to this type.
    */
   public String getDescriptor() {
-    // FIXME: this is not completely accurate at this point (for
-    // example, it knows nothing about the packages for compound
-    // types)
+    return getDescriptor(null);
+  }
+  public String getDescriptor(final JavaConfiguration cfg) {
     if (clazz != null) {
       return descriptor(clazz);
     }
     if( null != clazzName ) {
-        return descriptor(clazzName);
+        return descriptor((null != cfg ? (cfg.packageForStruct(clazzName) + ".") : "") + clazzName);
     }
     if( null != structName ) {
-        return descriptor(structName);
+        return descriptor((null != cfg ? (cfg.packageForStruct(structName) + ".") : "") + structName);
     }
     if (elementType != null) {
       if(elementType.getName()==null) {

--- a/src/junit/com/jogamp/gluegen/test/junit/generation/Test4JavaCallback.java
+++ b/src/junit/com/jogamp/gluegen/test/junit/generation/Test4JavaCallback.java
@@ -30,6 +30,7 @@ package com.jogamp.gluegen.test.junit.generation;
 
 import java.io.IOException;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.jogamp.common.os.NativeLibrary;
 import com.jogamp.gluegen.test.junit.generation.Bindingtest2.ALBUFFERCALLBACKTYPESOFT;
@@ -41,6 +42,7 @@ import com.jogamp.gluegen.test.junit.generation.Bindingtest2.MessageCallback11aK
 import com.jogamp.gluegen.test.junit.generation.Bindingtest2.MessageCallback11bKey;
 import com.jogamp.gluegen.test.junit.generation.Bindingtest2.T2_CallbackFunc01;
 import com.jogamp.gluegen.test.junit.generation.Bindingtest2.T2_CallbackFunc11;
+import com.jogamp.gluegen.test.junit.generation.Bindingtest2.T2_CallbackFunc12;
 import com.jogamp.gluegen.test.junit.generation.impl.Bindingtest2Impl;
 
 import org.junit.AfterClass;
@@ -1606,6 +1608,55 @@ public class Test4JavaCallback extends BaseClass {
         @Override
         public String toString() {
             return "CustomMessageCallback11Key[this "+toHexString(System.identityHashCode(this))+"]";
+        }
+    }
+
+    /**
+     * Test Bindingtest2 with T2_CallbackFunc12 JavaCallback via SetLogCallBack()
+     */
+    @Test
+    public void chapter12() throws Exception {
+        final Bindingtest2 bt2 = new Bindingtest2Impl();
+
+        final AtomicReference<LogMessage> messageSupplied = new AtomicReference<>(null);
+        final T2_CallbackFunc12 logCallBack = new T2_CallbackFunc12() {
+            @Override
+            public void callback(final LogMessage usrParam) {
+                Assert.assertEquals(messageSupplied.get(), usrParam);
+            }
+        };
+        bt2.SetLogCallBack(logCallBack);
+
+        {
+            final LogMessage logMessage = LogMessage.create();
+            logMessage.setCategory("TEST");
+            logMessage.setMessage("Example");
+            logMessage.setLevel(Bindingtest2.LOG_Info);
+            messageSupplied.set(logMessage);
+
+            bt2.LogCallBackInject(logMessage);
+        }
+
+        {
+            final LogMessage logMessage = LogMessage.create();
+            logMessage.setCategory("IDK");
+            logMessage.setMessage("John Doe is absent.");
+            logMessage.setLevel(Bindingtest2.LOG_Warning);
+            messageSupplied.set(logMessage);
+
+            bt2.LogCallBackInject(logMessage);
+        }
+
+        bt2.SetLogCallBack(null);
+
+        {
+            final LogMessage logMessage = LogMessage.create();
+            logMessage.setCategory("SANITY");
+            logMessage.setMessage("Callback is now unset");
+            logMessage.setLevel(Bindingtest2.LOG_Fatal);
+            messageSupplied.set(logMessage);
+
+            bt2.LogCallBackInject(logMessage);
         }
     }
 

--- a/src/junit/com/jogamp/gluegen/test/junit/generation/test2.c
+++ b/src/junit/com/jogamp/gluegen/test/junit/generation/test2.c
@@ -323,3 +323,21 @@ void MessageCallback11bInject(size_t id, long val) {
     }
 }
 
+
+//
+//
+
+static T2_CallbackFunc12 LogCallBack = NULL;
+
+void SetLogCallBack(T2_CallbackFunc12 cbFunc) {
+    LogCallBack = cbFunc;
+}
+
+void LogCallBackInject(const LogMessage* message) {
+    if ( NULL != LogCallBack ) {
+        fprintf(stderr, "XXX LogCallBackInject: func %p, message %p\n", &LogCallBack, &message);
+        fflush(NULL);
+        (*LogCallBack)(message);
+    }
+}
+

--- a/src/junit/com/jogamp/gluegen/test/junit/generation/test2.cfg
+++ b/src/junit/com/jogamp/gluegen/test/junit/generation/test2.cfg
@@ -179,6 +179,19 @@ JavaCallbackKey  MessageCallback11a 0 T2_CallbackFunc11 0
 JavaCallbackDef  MessageCallback11b 2 T2_CallbackFunc11 1
 JavaCallbackKey  MessageCallback11b 0 T2_CallbackFunc11 0
 
+
+ReturnsStringOnly LogMessage.Category
+ReturnsStringOnly LogMessage.Message
+
+# Begin JavaCallback
+#
+# typedef void ( * T2_CallbackFunc12)(const LogMessage* usrParam);
+# void SetLogCallBack(T2_CallbackFunc12 cbFunc);
+# void LogCallBackInject(LogMessage message);
+JavaCallbackDef SetLogCallBack -1 T2_CallbackFunc12 -1
+#
+# End JavaCallback
+
 CustomCCode #include "test2.h"
 
 Import com.jogamp.gluegen.test.junit.generation.Bindingtest2
@@ -187,6 +200,7 @@ Import com.jogamp.gluegen.test.junit.generation.T2_InitializeOptions
 Import com.jogamp.gluegen.test.junit.generation.T2_ThreadAffinity
 Import com.jogamp.gluegen.test.junit.generation.T2_UserData
 Import com.jogamp.gluegen.test.junit.generation.T2_Callback11UserType
+Import com.jogamp.gluegen.test.junit.generation.LogMessage
 Import com.jogamp.gluegen.test.junit.generation.Test4JavaCallback.ALCcontext
 
 CustomJavaCode Bindingtest2Impl  private static Bindingtest2ProcAddressTable _table = new Bindingtest2ProcAddressTable();

--- a/src/junit/com/jogamp/gluegen/test/junit/generation/test2.h
+++ b/src/junit/com/jogamp/gluegen/test/junit/generation/test2.h
@@ -108,3 +108,27 @@ void MessageCallback11aInject(size_t id, long val);
 void MessageCallback11b(size_t id /* key */, T2_CallbackFunc11 cbFunc, void* Data);
 void MessageCallback11bInject(size_t id, long val);
 
+//
+// T2_CallbackFunc12
+//
+
+typedef enum {
+	LOG_Off = 0,
+	LOG_Fatal = 100,
+	LOG_Error = 200,
+	LOG_Warning = 300,
+	LOG_Info = 400,
+	LOG_Verbose = 500,
+	LOG_VeryVerbose = 600
+} LogLevel;
+
+typedef struct {
+    const char* Category;
+    const char* Message;
+    LogLevel Level;
+} LogMessage;
+
+typedef void ( * T2_CallbackFunc12)(const LogMessage* usrParam);
+
+void SetLogCallBack(T2_CallbackFunc12 cbFunc);
+void LogCallBackInject(const LogMessage* message);


### PR DESCRIPTION
Here's a small modification on Java Callbacks, even if in our case we had a large number of functions with possibility to pass user parameters we have one and only one case in this API where we can't pass a user parameter, so here's the possibility of not passing one by specifying the position of the user parameter at -1 (in both the function call and the args of callback).