### PR TITLE
feat(callbackGenerator): Prevent generation of CallBack interface if setter related isn't present

### DIFF
--- a/src/java/com/jogamp/gluegen/DebugEmitter.java
+++ b/src/java/com/jogamp/gluegen/DebugEmitter.java
@@ -84,7 +84,8 @@ public class DebugEmitter implements GlueEmitter {
   @Override
   public void beginFunctions(final TypeDictionary typedefDictionary,
                              final TypeDictionary structDictionary,
-                             final Map<Type, Type> canonMap) {
+                             final Map<Type, Type> canonMap,
+                             List<FunctionSymbol> cFunctions) {
     final Set<String> keys = typedefDictionary.keySet();
     for (final String key: keys) {
       final Type value = typedefDictionary.get(key);

--- a/src/java/com/jogamp/gluegen/GlueEmitter.java
+++ b/src/java/com/jogamp/gluegen/GlueEmitter.java
@@ -75,7 +75,8 @@ public interface GlueEmitter {
 
   public void beginFunctions(TypeDictionary typedefDictionary,
                              TypeDictionary structDictionary,
-                             Map<Type, Type> canonMap) throws Exception;
+                             Map<Type, Type> canonMap,
+                             List<FunctionSymbol> cFunctions) throws Exception;
 
   /** Emit glue code for the list of FunctionSymbols. */
   public Iterator<FunctionSymbol> emitFunctions(List<FunctionSymbol> cFunctions) throws Exception;

--- a/src/java/com/jogamp/gluegen/GlueGen.java
+++ b/src/java/com/jogamp/gluegen/GlueGen.java
@@ -362,7 +362,7 @@ public class GlueGen implements GlueEmitterControls {
 
             if ( !cfg.structsOnly() ) {
                 // emit java and C code to interface with the native functions
-                emit.beginFunctions(td, sd, headerParser.getCanonMap());
+                emit.beginFunctions(td, sd, headerParser.getCanonMap(), allFunctions);
                 emit.emitFunctions(allFunctions);
                 emit.endFunctions();
             }

--- a/src/java/com/jogamp/gluegen/procaddress/ProcAddressEmitter.java
+++ b/src/java/com/jogamp/gluegen/procaddress/ProcAddressEmitter.java
@@ -78,13 +78,14 @@ public class ProcAddressEmitter extends JavaEmitter {
     protected String tableClassName;
 
     @Override
-    public void beginFunctions(final TypeDictionary typedefDictionary, final TypeDictionary structDictionary, final Map<Type, Type>  canonMap) throws Exception {
+    public void beginFunctions(final TypeDictionary typedefDictionary, final TypeDictionary structDictionary,
+                               final Map<Type, Type>  canonMap, final List<FunctionSymbol> cFunctions) throws Exception {
         this.typedefDictionary = typedefDictionary;
 
         if (getProcAddressConfig().emitProcAddressTable()) {
             beginProcAddressTable();
         }
-        super.beginFunctions(typedefDictionary, structDictionary, canonMap);
+        super.beginFunctions(typedefDictionary, structDictionary, canonMap, cFunctions);
     }
 
     @Override


### PR DESCRIPTION
In case when JavaCallbackDef directive is specified but setter of callback isn't present inside header file processed by Gluegen.

Application case :
You have main.cfg descriptor with all JavaCallbackDef diretives specified
You have subPart.cfg descriptor including main.cfg but subPart use only part of directives defined inside main.cfg