### PR TITLE
feat(cgram): Modify parsing of number inside GnuCParser because - inside path of line directives is captured as start of number

### DIFF
--- a/src/antlr/com/jogamp/gluegen/cgram/GnuCParser.g
+++ b/src/antlr/com/jogamp/gluegen/cgram/GnuCParser.g
@@ -791,7 +791,7 @@ protected NumberSuffix
         ;
     
 Number
-        :       ( ('-')? ( Digit )+ ( '.' | 'e' | 'E' ) )=> ('-')? ( Digit )+
+        :       ( ( Digit )+ ( '.' | 'e' | 'E' ) )=> ( Digit )+
                 ( '.' ( Digit )* ( Exponent )?
                 | Exponent
                 ) 
@@ -811,7 +811,7 @@ Number
                 ( NumberSuffix
                 )*
 
-        |       ('-')? '1'..'9' ( Digit )*     
+        |       '1'..'9' ( Digit )*
                 ( NumberSuffix
                 )*
 


### PR DESCRIPTION
Here's a modification to GnuCParser.g. Here, number parsing includes minus handling. However, in the file distributed by antlr, this minus is not present. (See here: https://www.antlr3.org/grammar/cgram/grammars/GnuCParser.g). This causes parsing errors with the jcpp preprocessor instruction in the following format:
#line number path number
In fact, if the path contains a dash, antlr may attempt to perform integer parsing on the path's components.
However, the declaration of expressions including minus signs is still possible, since GnuCParser extends StdCParser, which includes a number of operators, including this one
